### PR TITLE
Converters for unions

### DIFF
--- a/src/JsonNet.FSharp.sln
+++ b/src/JsonNet.FSharp.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "JsonNet.FSharp", "JsonNet.FSharp\JsonNet.FSharp.fsproj", "{BC6F1810-4D59-4216-8118-74A012643E4A}"
 EndProject
 Global

--- a/src/JsonNet.FSharp/JsonNet.FSharp.fsproj
+++ b/src/JsonNet.FSharp/JsonNet.FSharp.fsproj
@@ -48,6 +48,8 @@
     <Compile Include="OptionConverter.fs" />
     <Compile Include="TupleArrayConverter.fs" />
     <Compile Include="ListConverter.fs" />
+    <Compile Include="SingleCaseUnionConverter.fs" />
+    <Compile Include="UnionEnumConverter.fs" />
     <None Include="Script.fsx" />
   </ItemGroup>
   <PropertyGroup>

--- a/src/JsonNet.FSharp/JsonNet.FSharp.fsproj
+++ b/src/JsonNet.FSharp/JsonNet.FSharp.fsproj
@@ -11,6 +11,7 @@
     <AssemblyName>JsonNet.FSharp</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <Name>JsonNet.FSharp</Name>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -32,10 +33,10 @@
     <DocumentationFile>bin\Release\JsonNet.FSharp.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="mscorlib" />
-    <Reference Include="FSharp.Core, Version=4.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>True</Private>
     </Reference>
+    <Reference Include="mscorlib" />
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\lib\Newtonsoft.Json.dll</HintPath>
     </Reference>
@@ -52,7 +53,19 @@
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
   </PropertyGroup>
-  <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets" Condition=" Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')" />
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/JsonNet.FSharp/Script.fsx
+++ b/src/JsonNet.FSharp/Script.fsx
@@ -2,35 +2,44 @@
 #r "Newtonsoft.Json.dll"
 
 #load "OptionConverter.fs"
-open Newtonsoft.Json.FSharp
 
 #load "TupleArrayConverter.fs"
-open Newtonsoft.Json.FSharp
 
 #load "ListConverter.fs"
+
+#load "SingleCaseUnionConverter.fs"
+
+#load "UnionEnumConverter.fs"
+
 open Newtonsoft.Json.FSharp
 
 open System
 open Newtonsoft.Json
 
-type HaveAList = {
+type Email = Email of string
+
+type Role = Admin | Sysop | User
+
+type Employee = {
     Name : string
-    Roles : string list
-    Prefs : string * Int32
+    Roles : Role list
+    Location : string * Int32
+    Email : Email
 }
 
 let entity = { 
     Name = "Leo G"; 
-    Roles = ["admin"];
-    Prefs = ("hello",1985)
+    Roles = [Admin; User];
+    Location = ("Complex 4",4)
+    Email = Email "leo.g@corporation.com"
 }
 
-let converters : JsonConverter[] = [| new ListConverter(); new TupleArrayConverter() |]
+let converters : JsonConverter[] = [| new ListConverter(); new TupleArrayConverter(); new SingleCaseUnionConverter(); new UnionEnumConverter()|]
 
 let json = JsonConvert.SerializeObject(value=entity, converters=converters)
 
-assert (json = """{"Name":"Leo G","Roles":["admin"],"Prefs":["hello",1985]}""")
+assert (json = """{"Name":"Leo G","Roles":["Admin","User"],"Location":["Complex 4",4],"Email":"leo.g@corporation.com"}""")
 
-let back = JsonConvert.DeserializeObject<HaveAList>(value=json, converters=converters)
+let back = JsonConvert.DeserializeObject<Employee>(value=json, converters=converters)
 
 assert (back = entity)

--- a/src/JsonNet.FSharp/SingleCaseUnionConverter.fs
+++ b/src/JsonNet.FSharp/SingleCaseUnionConverter.fs
@@ -1,0 +1,25 @@
+﻿namespace Newtonsoft.Json.FSharp
+
+open System
+open Microsoft.FSharp.Reflection
+open Newtonsoft.Json
+open Newtonsoft.Json.Converters
+
+// Convert single case unions like "type Email = Email of string" to/from json. 
+type SingleCaseUnionConverter () =
+    inherit JsonConverter ()
+
+    override this.CanConvert(t) =
+        FSharpType.IsUnion(t) && FSharpType.GetUnionCases(t).Length = 1
+
+    override this.WriteJson(writer, value, serializer) =
+        let value = 
+            if value = null then null
+            else 
+                let _,fields = FSharpValue.GetUnionFields(value, value.GetType())
+                fields.[0]  
+        serializer.Serialize(writer, value)
+
+    override this.ReadJson(reader, t, existingValue, serializer) =
+        let value = serializer.Deserialize(reader)
+        if value <> null then FSharpValue.MakeUnion(FSharpType.GetUnionCases(t).[0],[|value|]) else null

--- a/src/JsonNet.FSharp/UnionEnumConverter.fs
+++ b/src/JsonNet.FSharp/UnionEnumConverter.fs
@@ -1,0 +1,32 @@
+﻿namespace Newtonsoft.Json.FSharp
+
+open System
+open Microsoft.FSharp.Reflection
+open Newtonsoft.Json
+open Newtonsoft.Json.Converters
+
+// Convert unions of form "type Union = A | B | C" to/from json strings
+type UnionEnumConverter () =
+    inherit JsonConverter ()
+
+    override this.CanConvert(t) =
+        FSharpType.IsUnion(t) &&
+        not (FSharpType.GetUnionCases(t) |> Array.exists (fun case -> case.GetFields().Length > 0))
+
+    override this.WriteJson(writer, value, serializer) =
+        let name =
+            if value = null then null
+            else
+                match FSharpValue.GetUnionFields(value, value.GetType()) with
+                | case, _ -> case.Name  
+        serializer.Serialize(writer,name)
+
+    override this.ReadJson(reader, t, existingValue, serializer) =
+        let value = serializer.Deserialize(reader,typeof<string>) :?> string
+
+        let case = FSharpType.GetUnionCases(t) |> Array.pick (fun case ->
+            // Note: Case insensitive match!
+            if case.Name.ToUpper() = value.ToUpper() then Some case else None
+        )
+
+        FSharpValue.MakeUnion(case,[||])


### PR DESCRIPTION
Hey!

I added some converters for some simple unions.

Single case unions like "type Email = Email of string" simply unwraps the inner type to/from json.

Union enums like "type Color = Red | Green | Blue" converts the case names to/from json.

I use them for stronger typing when deserializing responses from web services. 
